### PR TITLE
feat: add total fee calculation and product mapping to Order

### DIFF
--- a/src/models/member.py
+++ b/src/models/member.py
@@ -17,14 +17,8 @@ class Member:
     remain_delivery: int
     prepaid: int
 
-    def __post_init__(self):
-        if self.remain_delivery < 0:
-            raise ValueError("remain_delivery cannot be negative")
-        if self.prepaid < 0:
-            raise ValueError("prepaid cannot be negative")
-
     @classmethod
-    def from_dict(cls, data: Dict):
+    def from_dict(cls, data: Dict) -> "Member":
         return cls(
             member_id=format_uuid(data["member_id"]),
             line_id=data["line_id"],
@@ -45,3 +39,9 @@ class Member:
             "remain_delivery": self.remain_delivery,
             "prepaid": self.prepaid,
         }
+
+    def __post_init__(self):
+        if self.remain_delivery < 0:
+            raise ValueError("remain_delivery cannot be negative")
+        if self.prepaid < 0:
+            raise ValueError("prepaid cannot be negative")

--- a/src/models/product.py
+++ b/src/models/product.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+from typing import Any, Dict
+
+
+@dataclass
+class Product:
+    product_id: str
+    product_name: str
+    price: int
+
+    @classmethod
+    def from_dict(cls, data: Dict) -> "Product":
+        return cls(
+            product_id=data["product_id"],
+            product_name=data["product_name"],
+            price=data["price"],
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "product_id": self.product_id,
+            "product_name": self.product_name,
+            "price": self.price,
+        }
+
+    def __post_init__(self):
+        if self.price <= 0:
+            raise ValueError("price cannot be negative or zero.")

--- a/test/test_order.py
+++ b/test/test_order.py
@@ -4,10 +4,21 @@ from uuid import uuid4
 import pytest
 
 from src.models.order import Order
+from src.models.product import Product
 
 
 def test_order_valid_data(valid_order):
     assert valid_order.shipping_status == "pending"
+
+
+def test_order_calculate_total_fee(valid_order):
+    product_map = {
+        "P001": Product(product_id="P001", product_name="優格原味", price=100),
+        "P002": Product(product_id="P002", product_name="優格蜂蜜", price=120),
+    }
+    valid_order.orders = {"P001": 2, "P002": 1}  # 100 * 2  # 120 * 1
+    total = valid_order.calculate_total_fee(product_map)
+    assert total == 320
 
 
 def test_order_negative_total_fee():

--- a/test/test_product.py
+++ b/test/test_product.py
@@ -1,0 +1,21 @@
+import pytest
+
+from src.models.product import Product
+
+
+def test_product_valid():
+    product = Product(product_id="P001", product_name="優格原味", price=100)
+    assert product.product_id == "P001"
+    assert product.price == 100
+
+
+def test_product_zero_price():
+    with pytest.raises(ValueError) as exc:
+        Product(product_id="P002", product_name="試用品", price=0)
+    assert "price cannot be negative or zero" in str(exc.value)
+
+
+def test_product_negative_price():
+    with pytest.raises(ValueError) as exc:
+        Product(product_id="P003", product_name="錯誤商品", price=-50)
+    assert "price cannot be negative or zero" in str(exc.value)


### PR DESCRIPTION
### Summary

This PR integrates product-based pricing into the Order model and adds calculation methods for better order management.

### What's Included

- `Order.calculate_total_fee(product_map)` to compute total price from product info
- `Order.get_order_items(product_map)` to generate detailed item breakdown
- Updated `__post_init__` to ensure pricing validation remains strict
- Unit tests for total fee computation and item breakdown
- Verified compatibility with `Product` model and order dict structure

### Why

To allow future features like automatic invoice generation, accurate billing, and Google Sheet integration with centralized pricing data.

---

Please review the logic in `order.py` and corresponding tests. Let me know if anything should be refactored.
